### PR TITLE
Close dropmenu on menu button click

### DIFF
--- a/src/components/DropMenuButton.tsx
+++ b/src/components/DropMenuButton.tsx
@@ -62,7 +62,12 @@ const DropMenuButton: React.FunctionComponent<
   const buttonRef = useRef<any>(null);
 
   const handleClickOutside = (e: any) => {
-    if (dropMenuRef.current && !dropMenuRef.current.contains(e.target)) {
+    if (
+      dropMenuRef.current &&
+      !dropMenuRef.current.contains(e.target) &&
+      buttonRef.current !== e.target &&
+      !buttonRef.current.contains(e.target)
+    ) {
       setExpanded(false);
     }
   };


### PR DESCRIPTION
Clicking the menu button while the menu was open first triggered the callback registered by the "outside click" event. Then the button click triggered the callback to to immediately reopen in again, causing the menu to effectively stay open.